### PR TITLE
[skip ci] :construction_worker: Add conan args to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
       version: ${{ github.ref_name }}
       remote_url: https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
       modules_support_needed: true
+      extra_conan_arguments: -o "*:cxx_modules=True" -o "*:freestanding=True" -o "*:contracts=none" -o "*:import_std=False" -o "*:enable_rtti=False"
     secrets:
       conan_remote_password: ${{ secrets.JFROG_LIBHAL_TRUNK_ID_TOKEN }}
       conan_remote_user: ${{ secrets.JFROG_LIBHAL_TRUNK_ID_TOKEN_USER }}


### PR DESCRIPTION
Removing semantic release since we should be following mp-units